### PR TITLE
👌 IMPROVE: Switch to using .env file for docker setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ APPNAME=ColdBox
 ENVIRONMENT=development
 
 # Database Information
+DB_BUNDLEVERSION=8.0.19
+DB_BUNDLENAME=com.mysql.cj
 DB_CONNECTIONSTRING=jdbc:mysql://127.0.0.1:3306/coldbox?useSSL=false&useUnicode=true&characterEncoding=UTF-8&serverTimezone=UTC&useLegacyDatetimeCode=true
 DB_CLASS=com.mysql.jdbc.Driver
 DB_DRIVER=MySQL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,18 +44,14 @@ services:
       - coldbox_db
     platform: linux/x86_64 # Needed for Mac's on the M1 chip
     image: ortussolutions/commandbox:lucee5
-    # Environment Variables
+    # Pull in .env file as environment variables to the container
+    env_file:
+      - .env
+    # Docker-specific environment variables - will override values from env_file
     environment:
       CFCONFIG_ADMINPASSWORD: coldbox
       DB_HOST: coldbox_db
       DB_PORT: 4306
-      DB_DATABASE: coldbox
-      DB_DRIVER: MySQL
-      DB_USER: root
-      DB_PASSWORD: coldbox
-      DB_CLASS: com.mysql.jdbc.Driver
-      DB_BUNDLEVERSION: 8.0.19
-      DB_BUNDLENAME: com.mysql.cj
     # Ports
     ports:
       - "8080:8080"


### PR DESCRIPTION
This allows us to define coldbox app environment variables from the .env file as usual, but also to override them with docker-specific env vars if necessary.